### PR TITLE
remove astrocut pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pandas",
     "spherical_geometry>=1.2.22",
     "astroquery>=0.4",
-    "astrocut<=0.9",
+    "astrocut",
     "photutils>=2.0.0",
     "lxml",
     "PyPDF2",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example HLA-1234: <Fix a bug> -->
Resolves [HLA-1182](https://jira.stsci.edu/browse/HLA-1182)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #1720

<!-- describe the changes comprising this PR here -->
This PR addresses astrocut being pinned to 0.9. I wasn't able to immediately run the tests myself since I had some import errors with `ModuleNotFoundError: No module named 'ci_watson'`

**Checklist for maintainers**
- [ ] added entry in `CHANGELOG.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant label(s)